### PR TITLE
Conditionally enable missing art dictionary

### DIFF
--- a/artdaq-core/Data/CMakeLists.txt
+++ b/artdaq-core/Data/CMakeLists.txt
@@ -22,14 +22,22 @@ art_dictionary(DICTIONARY_LIBRARIES
   artdaq-core_Data_ParentageMap
 )
 
-get_target_property(DictCompileOptions artdaq-core_Data_dict COMPILE_OPTIONS)
-if(DictCompileOptions)
-	string(REPLACE "-fsanitize=thread" "" DictCompileOptions "${DictCompileOptions}")
-	string(REPLACE "-fsanitize=address" "" DictCompileOptions "${DictCompileOptions}")
-	string(REPLACE "-ltsan" "" DictCompileOptions "${DictCompileOptions}")
-	string(REPLACE "-lasan" "" DictCompileOptions "${DictCompileOptions}")
+function(disable_sanitizers DictName)
+  get_target_property(DictCompileOptions ${DictName} COMPILE_OPTIONS)
+  if(DictCompileOptions)
+        string(REPLACE "-fsanitize=thread" "" DictCompileOptions "${DictCompileOptions}")
+        string(REPLACE "-fsanitize=address" "" DictCompileOptions "${DictCompileOptions}")
+        string(REPLACE "-ltsan" "" DictCompileOptions "${DictCompileOptions}")
+        string(REPLACE "-lasan" "" DictCompileOptions "${DictCompileOptions}")
 
-	set_target_properties(artdaq-core_Data_dict PROPERTIES COMPILE_OPTIONS "${DictCompileOptions}")
+        set_target_properties(${DictName} PROPERTIES COMPILE_OPTIONS "${DictCompileOptions}")
+   endif()
+endfunction()
+
+disable_sanitizers(artdaq-core_Data_dict)
+
+if (${canvas_root_io_VERSION} VERSION_LESS 1.11.00)
+  add_subdirectory(MissingArtDictionaries)
 endif()
 
 install_headers(SUBDIRS detail)

--- a/artdaq-core/Data/MissingArtDictionaries/CMakeLists.txt
+++ b/artdaq-core/Data/MissingArtDictionaries/CMakeLists.txt
@@ -1,0 +1,6 @@
+art_dictionary()
+
+disable_sanitizers(artdaq-core_Data_MissingArtDictionaries_dict)
+
+install_headers()
+install_source()

--- a/artdaq-core/Data/MissingArtDictionaries/classes.h
+++ b/artdaq-core/Data/MissingArtDictionaries/classes.h
@@ -1,0 +1,2 @@
+#include "canvas/Persistency/Provenance/ProcessHistory.h"
+#include "canvas/Persistency/Provenance/ProcessHistoryID.h"

--- a/artdaq-core/Data/MissingArtDictionaries/classes_def.xml
+++ b/artdaq-core/Data/MissingArtDictionaries/classes_def.xml
@@ -1,0 +1,3 @@
+<lcgdict>
+  <class name="std::pair<art::ProcessHistoryID, art::ProcessHistory>"/>
+</lcgdict>

--- a/artdaq-core/Data/classes_def.xml
+++ b/artdaq-core/Data/classes_def.xml
@@ -32,5 +32,4 @@
     <class name="art::ParentageMap"/>
     <class name="std::pair<const art::ParentageID, art::Parentage>"/>
     <class name="std::pair<art::ParentageID, art::Parentage>"/>
-    <class name="std::pair<art::ProcessHistoryID, art::ProcessHistory>"/>
 </lcgdict>


### PR DESCRIPTION
The `std::pair<ProcessHistoryID, ProcessHistory>` dictionary is provided by canvas-root-io 1.11.00 and later.  This commit creates the dictionary only if the canvas-root-io version is older than 1.11.00.