### PR TITLE
Add s120 and s122 to qualifer list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required (VERSION 3.19 FATAL_ERROR)
 
 find_package(cetmodules 3.16.00 REQUIRED)
 
-project(artdaq_core VERSION 3.09.06 LANGUAGES CXX C)
+project(artdaq_core VERSION 3.09.07 LANGUAGES CXX C)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -21,6 +21,8 @@ old_style_config_vars
 
 #
 product			version		optional
+canvas_root_io  v1_12_01    s122
+canvas_root_io  v1_11_01    s120
 canvas_root_io  v1_11_01    s119
 canvas_root_io	v1_11_00	s118
 canvas_root_io	v1_10_02	s116
@@ -31,12 +33,30 @@ canvas_root_io	v1_09_05	s117
 canvas_root_io	v1_09_04a	s112a
 canvas_root_io	v1_09_04	s112
 TRACE			v3_17_07
-cetmodules		v3_19_02	-	only_for_build
+cetmodules		v3_21_00	-	only_for_build
 end_product_list
 
 # -nq- means there is no qualifier
 # a "-" means the dependent product is not required by the parent and will not be setup
 qualifier		canvas_root_io	TRACE	notes
+c14:s122:debug	c14:debug		-nq-	-std=c++17
+c14:s122:prof	c14:prof		-nq-	-std=c++17
+c15:s122:debug	c15:debug		-nq-	-std=c++17
+c15:s122:prof	c15:prof		-nq-	-std=c++17
+e20:s122:debug	e20:debug		-nq-	-std=c++17
+e20:s122:prof	e20:prof		-nq-	-std=c++17
+e26:s122:debug	e26:debug		-nq-	-std=c++17
+e26:s122:prof	e26:prof		-nq-	-std=c++17
+
+c7:s120:debug	c7:debug		-nq-	-std=c++17
+c7:s120:prof	c7:prof			-nq-	-std=c++17
+c14:s120:debug	c14:debug		-nq-	-std=c++17
+c14:s120:prof	c14:prof		-nq-	-std=c++17
+e20:s120:debug	e20:debug		-nq-	-std=c++17
+e20:s120:prof	e20:prof		-nq-	-std=c++17
+e26:s120:debug	e26:debug		-nq-	-std=c++17
+e26:s120:prof	e26:prof		-nq-	-std=c++17
+
 c7:s119:debug	c7:debug		-nq-	-std=c++17
 c7:s119:prof	c7:prof			-nq-	-std=c++17
 c14:s119:debug	c14:debug		-nq-	-std=c++17


### PR DESCRIPTION
`s122` supports art 3.13.01 and is the first qualifier to support `c15` (Clang 15 with C++17).  This PR also uses an updated version of`cetmodules`, which is required to support `c15`.