### PR TITLE
Add CMakePresets.cmake to the repository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 bin/*
 obj/*
 *.vcxproj*
-CMakePresets.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,140 @@
+{
+   "configurePresets" : [
+      {
+         "cacheVariables" : {
+            "CMAKE_BUILD_TYPE" : {
+               "type" : "STRING",
+               "value" : "RelWithDebInfo"
+            },
+            "CMAKE_CXX_EXTENSIONS" : {
+               "type" : "BOOL",
+               "value" : "OFF"
+            },
+            "CMAKE_CXX_STANDARD_REQUIRED" : {
+               "type" : "BOOL",
+               "value" : "ON"
+            },
+            "artdaq_core_ADD_ARCH_DIRS_INIT" : {
+               "type" : "INTERNAL",
+               "value" : "LIBRARY_DIR;BIN_DIR"
+            },
+            "artdaq_core_ADD_NOARCH_DIRS_INIT" : {
+               "type" : "INTERNAL",
+               "value" : "INCLUDE_DIR;PERLLIB_DIR"
+            },
+            "artdaq_core_BIN_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : "bin"
+            },
+            "artdaq_core_FHICL_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : ""
+            },
+            "artdaq_core_INCLUDE_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : "include"
+            },
+            "artdaq_core_LIBRARY_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : "lib"
+            },
+            "artdaq_core_OLD_STYLE_CONFIG_VARS_INIT" : {
+               "type" : "BOOL",
+               "value" : true
+            }
+         },
+         "description" : "Configuration settings translated from ups/product_deps",
+         "displayName" : "Configuration from product_deps",
+         "hidden" : true,
+         "name" : "from_product_deps"
+      },
+      {
+         "cacheVariables" : {
+            "CMAKE_CXX_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER}"
+            },
+            "CMAKE_CXX_STANDARD" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_STANDARD}"
+            },
+            "CMAKE_C_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER}"
+            },
+            "CMAKE_Fortran_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER}"
+            },
+            "UPS_CXX_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_ID}"
+            },
+            "UPS_CXX_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_VERSION}"
+            },
+            "UPS_C_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_ID}"
+            },
+            "UPS_C_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_VERSION}"
+            },
+            "UPS_Fortran_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_ID}"
+            },
+            "UPS_Fortran_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_VERSION}"
+            },
+            "WANT_UPS" : {
+               "type" : "BOOL",
+               "value" : true
+            },
+            "artdaq_core_EXEC_PREFIX_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FQ_DIR}"
+            },
+            "artdaq_core_UPS_BUILD_ONLY_DEPENDENCIES_INIT" : {
+               "type" : "STRING",
+               "value" : "cetmodules"
+            },
+            "artdaq_core_UPS_PRODUCT_FLAVOR_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FLAVOR}"
+            },
+            "artdaq_core_UPS_PRODUCT_NAME_INIT" : {
+               "type" : "STRING",
+               "value" : "artdaq_core"
+            },
+            "artdaq_core_UPS_QUALIFIER_STRING_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_QUALSPEC}"
+            }
+         },
+         "description" : "Extra configuration for UPS package generation",
+         "displayName" : "UPS extra configuration",
+         "hidden" : true,
+         "name" : "extra_for_UPS"
+      },
+      {
+         "description" : "Default configuration including settings from ups/product_deps",
+         "displayName" : "Default configuration",
+         "inherits" : "from_product_deps",
+         "name" : "default"
+      },
+      {
+         "description" : "Default configuration for UPS package generation",
+         "displayName" : "Default configuration for UPS",
+         "inherits" : [
+            "default",
+            "extra_for_UPS"
+         ],
+         "name" : "for_UPS"
+      }
+   ],
+   "version" : 3
+}


### PR DESCRIPTION
(Re-)Generated during the CMake configure phase by
`setup_for_development` (except when using MRB), CMakePresets.cmake is
intended to bridge the UPS and Spack worlds. CMake cache variables
influenced by the UPS-based `product_deps` file are recorded in this
file for use when `setup_for_development` is no longer appropriate or
available.

Add the following to your Spack recipe in order to use it:

```.py
    def cmake_args(self):
        return [
           "--preset", "default",
           ...,
        ]
```

This will set CMake cache variables appropriate for non-UPS-based
builds. To build with and for UPS, use the preset, `for_ups` instead of
`default`.

Once `setup_for_development` is no longer used, the presets file should
be pruned of UPS-only settings and updated manually as the
needs of the package (rarely) change.

This preset currently includes the setting,
`artdaq_core_OLD_STYLE_CONFIG_VARS:BOOL=ON` (automatically generated
from `product_deps` via the keyword `old_style_config_vars`) which preserves correct operation of the
documentation generation (see #30).
