### PR TITLE
Support for s124 and e28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required (VERSION 3.19 FATAL_ERROR)
 
 find_package(cetmodules 3.16.00 REQUIRED)
 
-project(artdaq_core VERSION 3.09.11 LANGUAGES CXX C)
+project(artdaq_core VERSION 3.09.12 LANGUAGES CXX C)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -21,17 +21,29 @@ old_style_config_vars
 
 #
 product			version		optional
+canvas_root_io  v1_12_03    s124
 canvas_root_io  v1_12_02    s123
 canvas_root_io  v1_11_02    s120a
 canvas_root_io  v1_11_01    s120
 canvas_root_io	v1_09_04	s112
 TRACE			v3_17_09
-cetmodules		v3_21_01	-	only_for_build
+cetmodules		v3_21_02	-	only_for_build
 end_product_list
 
 # -nq- means there is no qualifier
 # a "-" means the dependent product is not required by the parent and will not be setup
 qualifier		canvas_root_io	TRACE	notes
+c14:s124:debug	c14:debug		-nq-	-std=c++17
+c14:s124:prof	c14:prof		-nq-	-std=c++17
+c15:s124:debug	c15:debug		-nq-	-std=c++17
+c15:s124:prof	c15:prof		-nq-	-std=c++17
+e20:s124:debug	e20:debug		-nq-	-std=c++17
+e20:s124:prof	e20:prof		-nq-	-std=c++17
+e26:s124:debug	e26:debug		-nq-	-std=c++17
+e26:s124:prof	e26:prof		-nq-	-std=c++17
+e28:s124:debug	e28:debug		-nq-	-std=c++20
+e28:s124:prof	e28:prof		-nq-	-std=c++20
+
 c14:s123:debug	c14:debug		-nq-	-std=c++17
 c14:s123:prof	c14:prof		-nq-	-std=c++17
 c15:s123:debug	c15:debug		-nq-	-std=c++17


### PR DESCRIPTION
Includes `v3_09_12` tag.