### PR TITLE
Ignore more Spack build artifacts. Add INSTALL_BIN to cet_test calls …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ obj/*
 core.*
 spack-build-*
 spack-configure-*
+build-linux-*
+

--- a/test/Core/CMakeLists.txt
+++ b/test/Core/CMakeLists.txt
@@ -1,13 +1,13 @@
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
-  cet_test(SharedMemoryManager_t USE_BOOST_UNIT
+  cet_test(SharedMemoryManager_t USE_BOOST_UNIT INSTALL_BIN
     LIBRARIES PRIVATE
     artdaq-core_Core
     artdaq-core_Utilities
     cetlib::headers
     cetlib_except::cetlib_except
   )
-  cet_test(SharedMemoryFragmentManager_t USE_BOOST_UNIT
+  cet_test(SharedMemoryFragmentManager_t USE_BOOST_UNIT INSTALL_BIN
     LIBRARIES PRIVATE
     artdaq-core_Core 
     artdaq-core_Data

--- a/test/Data/CMakeLists.txt
+++ b/test/Data/CMakeLists.txt
@@ -1,23 +1,23 @@
 
-cet_test(Fragment_t USE_BOOST_UNIT
+cet_test(Fragment_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq-core_Data
   cetlib::headers
 )
 
-cet_test(ContainerFragment_t USE_BOOST_UNIT
+cet_test(ContainerFragment_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq-core_Data
   cetlib::headers
 )
 
-cet_test(RawEvent_t USE_BOOST_UNIT
+cet_test(RawEvent_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq-core_Data
   cetlib::headers
 )
 
-cet_test(BuildInfo_t USE_BOOST_UNIT
+cet_test(BuildInfo_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq-core_Data
   cetlib::headers

--- a/test/Plugins/CMakeLists.txt
+++ b/test/Plugins/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-cet_test(FragmentGenerator_t USE_BOOST_UNIT
+cet_test(FragmentGenerator_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq_plugin_types::generator
   cetlib::headers
 )
   
-cet_test(FragmentNameHelper_t USE_BOOST_UNIT
+cet_test(FragmentNameHelper_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq_plugin_types::fragmentNameHelper
   cetlib::headers

--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -1,11 +1,11 @@
-cet_test(TimeUtils_t USE_BOOST_UNIT
+cet_test(TimeUtils_t USE_BOOST_UNIT INSTALL_BIN
 	LIBRARIES PRIVATE
   artdaq-core_Utilities
   cetlib::headers
   TRACE::MF
 )
 
-cet_test(ExceptionHandler_t USE_BOOST_UNIT
+cet_test(ExceptionHandler_t USE_BOOST_UNIT INSTALL_BIN
 	LIBRARIES PRIVATE
   artdaq-core_Utilities
 	canvas::canvas
@@ -14,7 +14,7 @@ cet_test(ExceptionHandler_t USE_BOOST_UNIT
   TRACE::MF
 )
 
-cet_test(SimpleLookupPolicy_t USE_BOOST_UNIT
+cet_test(SimpleLookupPolicy_t USE_BOOST_UNIT INSTALL_BIN
 	DATAFILES fcl/LookupTarget.fcl
 	LIBRARIES PRIVATE
   artdaq-core_Utilities
@@ -24,14 +24,14 @@ cet_test(SimpleLookupPolicy_t USE_BOOST_UNIT
   Boost::filesystem
 )
 
-cet_test(ExceptionStackTrace_t USE_BOOST_UNIT
+cet_test(ExceptionStackTrace_t USE_BOOST_UNIT INSTALL_BIN
 	LIBRARIES PRIVATE
   artdaq-core_Utilities_ExceptionStackTrace
   cetlib::headers
   TRACE::MF
 )
 
-cet_test(configureMessageFacility_t USE_BOOST_UNIT
+cet_test(configureMessageFacility_t USE_BOOST_UNIT INSTALL_BIN
 	LIBRARIES PRIVATE
   artdaq-core_Utilities
   fhiclcpp::fhiclcpp
@@ -41,7 +41,7 @@ cet_test(configureMessageFacility_t USE_BOOST_UNIT
   Boost::filesystem
 )
 
-cet_test(GenFile_t USE_BOOST_UNIT
+cet_test(GenFile_t USE_BOOST_UNIT INSTALL_BIN
 	LIBRARIES PRIVATE
   artdaq-core_Utilities
   messagefacility::MF_MessageLogger


### PR DESCRIPTION
…so that the unit tests can be run from installed products