### PR TITLE
Cache reader_pos and writer_pos in ReadyForRead and ReadyForWrite if a

### DIFF
--- a/artdaq-core/Core/SharedMemoryManager.cc
+++ b/artdaq-core/Core/SharedMemoryManager.cc
@@ -392,7 +392,7 @@ int artdaq::SharedMemoryManager::GetBufferForReading()
 	return -1;
 }
 
-int artdaq::SharedMemoryManager::GetBufferForWriting(bool overwrite)
+int artdaq::SharedMemoryManager::GetBufferForWriting(bool overwrite, size_t sequence_id_override)
 {
 	TLOG(TLVL_GETBUFFER + 1) << "GetBufferForWriting BEGIN, overwrite=" << (overwrite ? "true" : "false");
 
@@ -430,7 +430,7 @@ int artdaq::SharedMemoryManager::GetBufferForWriting(bool overwrite)
 				continue;
 			}
 			writer_pos_ = (buffer + 1) % shm_ptr_->buffer_count;
-			buf->sequence_id = ++shm_ptr_->next_sequence_id;
+			buf->sequence_id = sequence_id_override == 0 ? ++shm_ptr_->next_sequence_id : sequence_id_override;
 			buf->writePos = 0;
 			if (!checkBuffer_(buf, BufferSemaphoreFlags::Writing, false))
 			{
@@ -472,7 +472,7 @@ int artdaq::SharedMemoryManager::GetBufferForWriting(bool overwrite)
 					continue;
 				}
 				writer_pos_ = (buffer + 1) % shm_ptr_->buffer_count;
-				buf->sequence_id = ++shm_ptr_->next_sequence_id;
+				buf->sequence_id = sequence_id_override == 0 ? ++shm_ptr_->next_sequence_id : sequence_id_override;
 				buf->writePos = 0;
 				if (!checkBuffer_(buf, BufferSemaphoreFlags::Writing, false))
 				{
@@ -512,7 +512,7 @@ int artdaq::SharedMemoryManager::GetBufferForWriting(bool overwrite)
 					continue;
 				}
 				writer_pos_ = (buffer + 1) % shm_ptr_->buffer_count;
-				buf->sequence_id = ++shm_ptr_->next_sequence_id;
+				buf->sequence_id = sequence_id_override == 0 ? ++shm_ptr_->next_sequence_id : sequence_id_override;
 				buf->writePos = 0;
 				if (!checkBuffer_(buf, BufferSemaphoreFlags::Writing, false))
 				{
@@ -638,6 +638,7 @@ bool artdaq::SharedMemoryManager::ReadyForRead()
 		{
 			TLOG(TLVL_READREADY + 3) << std::hex << std::showbase << shm_key_ << std::dec << " ReadyForRead: Buffer " << buffer << " is either unowned or owned by this manager, and is marked full.";
 			touchBuffer_(buf);
+			reader_pos_ = buffer;  // Advance reader position to this buffer so that next search starts from here
 			return true;
 		}
 	}
@@ -671,7 +672,8 @@ bool artdaq::SharedMemoryManager::ReadyForWrite(bool overwrite)
 		{
 			TLOG(TLVL_WRITEREADY + 1) << std::hex << std::showbase << shm_key_
 			                          << std::dec
-			                          << " ReadyForWrite: Buffer " << ii << " is either empty or available for overwrite.";
+			                          << " ReadyForWrite: Buffer " << buffer << " is either empty or available for overwrite.";
+			writer_pos_ = buffer;  // Advance writer position to this buffer so that next search starts from here
 			return true;
 		}
 	}

--- a/artdaq-core/Core/SharedMemoryManager.hh
+++ b/artdaq-core/Core/SharedMemoryManager.hh
@@ -83,9 +83,10 @@ public:
 	/**
 	 * \brief Finds a buffer that is ready to be written to, and reserves it for the calling manager.
 	 * \param overwrite Whether to consider buffers that are in the Full and Reading state as ready for write (non-reliable mode)
+	 * \param sequence_id_override If non-zero, override the buffer sequence ID with the provided value for read ordering
 	 * \return The id number of the buffer. -1 indicates no buffers available for write.
 	 */
-	int GetBufferForWriting(bool overwrite);
+	int GetBufferForWriting(bool overwrite, size_t sequence_id_override = 0);
 
 	/**
 	 * \brief Whether any buffer is ready for read


### PR DESCRIPTION
readable/writable buffer is found.

Add option to GetBufferForWriting to specify sequence ID (so that it can match artdaq's sequence ID), allowing for better sequencing of events to readers.